### PR TITLE
Swift debugger breaks down on complex macros.  We won't be targeting any...

### DIFF
--- a/SDWebImage/SDWebImageCompat.h
+++ b/SDWebImage/SDWebImageCompat.h
@@ -13,10 +13,6 @@
 #error SDWebImage does not support Objective-C Garbage Collection
 #endif
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_5_0
-#error SDWebImage doesn't support Deployement Target version < 5.0
-#endif
-
 #if !TARGET_OS_IPHONE
 #import <AppKit/AppKit.h>
 #ifndef UIImage


### PR DESCRIPTION
...body less than iOS 5.0, so kill this macro.
